### PR TITLE
Fixed bug about levels on php-cs-fixer

### DIFF
--- a/src/PhpGitHooks/Module/PhpCsFixer/Service/PhpCsFixerTool.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Service/PhpCsFixerTool.php
@@ -42,19 +42,19 @@ class PhpCsFixerTool
     public function execute(array $files, $psr0, $psr1, $psr2, $symfony, $errorMessage)
     {
         if (true === $psr0) {
-            $this->executeTool($files, 'PSR0', $errorMessage);
+            $this->executeTool($files, 'psr0', $errorMessage);
         }
 
         if (true === $psr1) {
-            $this->executeTool($files, 'PSR1', $errorMessage);
+            $this->executeTool($files, 'psr1', $errorMessage);
         }
 
         if (true === $psr2) {
-            $this->executeTool($files, 'PSR2', $errorMessage);
+            $this->executeTool($files, 'psr2', $errorMessage);
         }
 
         if (true === $symfony) {
-            $this->executeTool($files, 'SYMFONY', $errorMessage);
+            $this->executeTool($files, 'symfony', $errorMessage);
         }
     }
 

--- a/src/PhpGitHooks/Module/PhpCsFixer/Tests/Behaviour/PhpCsFixerToolCommandHandlerTest.php
+++ b/src/PhpGitHooks/Module/PhpCsFixer/Tests/Behaviour/PhpCsFixerToolCommandHandlerTest.php
@@ -39,13 +39,13 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $configurationData = ConfigurationDataResponseStub::createAllEnabled();
         $phpFiles = FilesCommittedStub::createOnlyPhpFiles();
 
-        $outputMessage = new PreCommitOutputWriter('Checking PSR0 code style with PHP-CS-FIXER');
+        $outputMessage = new PreCommitOutputWriter('Checking psr0 code style with PHP-CS-FIXER');
         $this->shouldWriteOutput($outputMessage->getMessage());
 
         $errors = null;
         foreach ($phpFiles as $file) {
             $errorText = 'ERROR';
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR0', $errorText);
+            $this->shouldProcessPhpCsFixerTool($file, 'psr0', $errorText);
             $errors .= $errorText;
         }
 
@@ -73,38 +73,38 @@ class PhpCsFixerToolCommandHandlerTest extends PhpCsFixerUnitTestCase
         $configurationData = ConfigurationDataResponseStub::createAllEnabled();
         $phpFiles = FilesCommittedStub::createOnlyPhpFiles();
 
-        $outputMessagePsr0 = new PreCommitOutputWriter('Checking PSR0 code style with PHP-CS-FIXER');
+        $outputMessagePsr0 = new PreCommitOutputWriter('Checking psr0 code style with PHP-CS-FIXER');
         $this->shouldWriteOutput($outputMessagePsr0->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR0', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'psr0', null);
         }
 
         $this->shouldWriteLnOutput($outputMessagePsr0->getSuccessfulMessage());
 
-        $outputMessagePsr1 = new PreCommitOutputWriter('Checking PSR1 code style with PHP-CS-FIXER');
+        $outputMessagePsr1 = new PreCommitOutputWriter('Checking psr1 code style with PHP-CS-FIXER');
         $this->shouldWriteOutput($outputMessagePsr1->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR1', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'psr1', null);
         }
 
         $this->shouldWriteLnOutput($outputMessagePsr1->getSuccessfulMessage());
 
-        $outputMessagePsr2 = new PreCommitOutputWriter('Checking PSR2 code style with PHP-CS-FIXER');
+        $outputMessagePsr2 = new PreCommitOutputWriter('Checking psr2 code style with PHP-CS-FIXER');
         $this->shouldWriteOutput($outputMessagePsr2->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'PSR2', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'psr2', null);
         }
 
         $this->shouldWriteLnOutput($outputMessagePsr2->getSuccessfulMessage());
 
-        $outputMessageSymfony = new PreCommitOutputWriter('Checking SYMFONY code style with PHP-CS-FIXER');
+        $outputMessageSymfony = new PreCommitOutputWriter('Checking symfony code style with PHP-CS-FIXER');
         $this->shouldWriteOutput($outputMessageSymfony->getMessage());
 
         foreach ($phpFiles as $file) {
-            $this->shouldProcessPhpCsFixerTool($file, 'SYMFONY', null);
+            $this->shouldProcessPhpCsFixerTool($file, 'symfony', null);
         }
 
         $this->shouldWriteLnOutput($outputMessageSymfony->getSuccessfulMessage());


### PR DESCRIPTION
Hello,

At Ironweb, we tried to use the php-git-hook to have pre-commit hook with php-cs-fixer.

Unfortunately, it didn't work at first. After investigation, we've discovered that the command run by PhpCsFixerToolProcessor in processTool() was throwing an error 'the level "PSR0" is
not defined'.

We tried to run the command with lower case and it worked.

In order to correct this issue, we have replaced upper case to lower case for the levels in PhpCsFixerTool.php (in the method execute()).

Also, we have updated the tests accordingly.

Thanks in advance for your returns,
Ironweb Team.