### PR TITLE
Corrected version of php used in pre-commit, commit-msg and pre-push

### DIFF
--- a/src/PhpGitHooks/Infrastructure/Hook/commit-msg
+++ b/src/PhpGitHooks/Infrastructure/Hook/commit-msg
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 use PhpGitHooks\Infrastructure\Hook\CommitMsg;

--- a/src/PhpGitHooks/Infrastructure/Hook/pre-commit
+++ b/src/PhpGitHooks/Infrastructure/Hook/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 require __DIR__.'/../../vendor/autoload.php';

--- a/src/PhpGitHooks/Infrastructure/Hook/pre-push
+++ b/src/PhpGitHooks/Infrastructure/Hook/pre-push
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 use PhpGitHooks\Infrastructure\Hook\PrePush;


### PR DESCRIPTION
When the .git/hook/pre-commit was triggered, I had a 
```
Fatal error: Arrays are not allowed in class constants in /Users/quentinM-Dev/Documents/Projects/ironreactor/server/ir-main/vendor/ouserverdev/ir-definition-module/lib/Autoloading/AutoloadGeneratorTemplate.php on line 37
```

because the php version used was /usr/bin/php which was <5.6.
I needed to use the php version from /usr/local/bin/php.

To avoid this issue, we now use #!/usr/bin/env php.